### PR TITLE
Treat hashable objects as primitives

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -3,6 +3,8 @@ import MixedTupleMap from '../index';
 describe('MixedTupleMap', () => {
   let cache
   const obj = {'Carole Granade-Segers': 'Human unicorn'};
+  const hashableObj = Object.assign({}, obj, {hash: () => '#yolo'});
+  const hashableObjClone = Object.assign({}, hashableObj);
   const arr = ['Carole', 'Granade', 'Segers', 'we', 'love', 'you'];
   const str = 'Knee Breaker';
   const int = 1337;
@@ -62,6 +64,17 @@ describe('MixedTupleMap', () => {
       expect(cache.has([arr])).toEqual(false);
       expect(cache.get([obj])).toBe(res);
       expect(cache.get([fun])).toEqual(undefined);
+    });
+
+    it('should work with `({})` with hash function', () => {
+      cache.set([hashableObj], res);
+
+      expect(cache.has([hashableObj])).toEqual(true);
+      expect(cache.has([hashableObjClone])).toEqual(true);
+      expect(cache.has([obj])).toEqual(false);
+      expect(cache.get([hashableObj])).toBe(res);
+      expect(cache.get([hashableObjClone])).toBe(res);
+      expect(cache.get([obj])).toEqual(undefined);
     });
 
     it('should work with ({}, "str")', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -3,7 +3,7 @@ import MixedTupleMap from '../index';
 describe('MixedTupleMap', () => {
   let cache
   const obj = {'Carole Granade-Segers': 'Human unicorn'};
-  const hashableObj = Object.assign({}, obj, {hash: () => '#yolo'});
+  const hashableObj = Object.assign({}, obj, {hashCode: () => '#yolo'});
   const hashableObjClone = Object.assign({}, hashableObj);
   const arr = ['Carole', 'Granade', 'Segers', 'we', 'love', 'you'];
   const str = 'Knee Breaker';
@@ -66,7 +66,7 @@ describe('MixedTupleMap', () => {
       expect(cache.get([fun])).toEqual(undefined);
     });
 
-    it('should work with `({})` with hash function', () => {
+    it('should work with `({})` with hashCode function', () => {
       cache.set([hashableObj], res);
 
       expect(cache.has([hashableObj])).toEqual(true);

--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@ function MixedTupleMap() {
   this.clear();
 }
 
+const HASHED_INDEX = -1;
+const DUMMY_ARG = [];
+
+function getArgOrHashDummy(tuple, index) {
+  return index === HASHED_INDEX ? DUMMY_ARG : tuple[index];
+}
+
 MixedTupleMap.prototype = {
   toString: function() {
     return '[object MixedTupleMap]';
@@ -25,7 +32,11 @@ MixedTupleMap.prototype = {
     for( let i = 0; i < l; i++) {
       let arg = tuple[i];
       let argType = typeof arg;
-      if ( argType !== null && ( argType === 'object' || argType === 'function' ) ) {
+      if (arg && typeof arg.hash === 'function') {
+        prim.push( '' + arg.hash() );
+        primOrder.push( i );
+        nonPrimOrder.push( HASHED_INDEX );
+      } else if ( argType !== null && ( argType === 'object' || argType === 'function' ) ) {
         nonPrimOrder.push( i );
       } else {
         prim.push( argType === 'string' ? '"' + arg + '"' : '' + arg );
@@ -56,7 +67,7 @@ MixedTupleMap.prototype = {
     const l = hash.nonPrimOrder.length;
 
     for( let i = 0; i < l; i++) {
-      const arg = tuple[hash.nonPrimOrder[i]]
+      const arg = getArgOrHashDummy(tuple, hash.nonPrimOrder[i]);
       if ( curr.has && curr.has(arg) ) {
         curr = curr.get(arg);
       } else {
@@ -74,7 +85,7 @@ MixedTupleMap.prototype = {
     let mustCreate = false;
 
     for( let i = 0; i < l; i++) {
-      const arg = tuple[hash.nonPrimOrder[i]]
+      const arg = getArgOrHashDummy(tuple, hash.nonPrimOrder[i]);
       if ( !mustCreate && curr.has(arg) ) {
         curr = curr.get(arg);
       } else {
@@ -94,7 +105,7 @@ MixedTupleMap.prototype = {
     const l = hash.nonPrimOrder.length;
 
     for( let i = 0; i < l; i++) {
-      const arg = tuple[hash.nonPrimOrder[i]]
+      const arg = getArgOrHashDummy(tuple, hash.nonPrimOrder[i]);
       const ret = curr.get && curr.get(arg);
       if ( ret === undefined ) {
         return ret;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ function MixedTupleMap() {
 const HASHED_INDEX = -1;
 const DUMMY_ARG = [];
 
+// Return the argument at the given index, or a dummy argument for hashed non-primitives.
 function getArgOrHashDummy(tuple, index) {
   return index === HASHED_INDEX ? DUMMY_ARG : tuple[index];
 }
@@ -32,9 +33,11 @@ MixedTupleMap.prototype = {
     for( let i = 0; i < l; i++) {
       let arg = tuple[i];
       let argType = typeof arg;
-      if (arg && typeof arg.hash === 'function') {
-        prim.push( '' + arg.hash() );
+      // Immutable.js and similar libraries implement `hashCode` for efficient object comparison.
+      if (arg && typeof arg.hashCode === 'function') {
+        prim.push( '' + arg.hashCode() );
         primOrder.push( i );
+        // Add a dummy index to signify this non-primitive argument was hashed into a primitive argument.
         nonPrimOrder.push( HASHED_INDEX );
       } else if ( argType !== null && ( argType === 'object' || argType === 'function' ) ) {
         nonPrimOrder.push( i );


### PR DESCRIPTION
This allows objects with a `hashCode` function to be cached using their hash value rather than the object itself. This leads to major performance gains when using Immutable.js and similar ([hashCode docs](https://facebook.github.io/immutable-js/docs/#/Map/hashCode)).

See tests for an example.